### PR TITLE
Use an atomic for GlobalCallIndex.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "smockable",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .watchOS(.v6), .tvOS(.v13),
+        .macOS(.v15), .iOS(.v18), .watchOS(.v11), .tvOS(.v18),
     ],
     products: [
         .library(

--- a/Sources/SmockMacro/Generator/ReceivedInvocationsGenerator.swift
+++ b/Sources/SmockMacro/Generator/ReceivedInvocationsGenerator.swift
@@ -94,7 +94,7 @@ enum ReceivedInvocationsGenerator {
 
         return ExprSyntax(
             """
-            await \(identifier).\(raw: variablePrefix).append(\(argument))
+            \(identifier).\(raw: variablePrefix).append(\(argument))
             """
         )
     }

--- a/Sources/Smockable/GlobalCallIndex.swift
+++ b/Sources/Smockable/GlobalCallIndex.swift
@@ -3,13 +3,15 @@
 //  smockable
 //
 
-public actor GlobalCallIndex {
-    private var value: UInt32 = 0
+import Synchronization
+
+public struct GlobalCallIndex: ~Copyable, Sendable {
+    private let value = Atomic<UInt32>(0)
 
     public func getCurrentIndex() -> UInt32 {
-        self.value += 1
+        let (_, updatedValue) = self.value.add(1, ordering: .sequentiallyConsistent)
 
-        return self.value
+        return updatedValue
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use an atomic for GlobalCallIndex.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
