### PR TITLE
Walk the syntax tree for generic argument parsing. Support some types.

### DIFF
--- a/Sources/SmockMacro/Generator/ReceivedInvocationsGenerator.swift
+++ b/Sources/SmockMacro/Generator/ReceivedInvocationsGenerator.swift
@@ -98,20 +98,11 @@ enum ReceivedInvocationsGenerator {
                 TupleTypeElementSyntax(
                     firstName: parameter.secondName ?? parameter.firstName,
                     colon: .colonToken(),
-                    type: function.erasedType(for: strippedAttributedType(parameter.type))
+                    type: function.erasedType(for: parameter.type)
                 )
             }
         }
         return TupleTypeSyntax(elements: tupleElements)
-    }
-
-    /// Strip attribute decorations (e.g. `inout`) so the underlying type can be
-    /// stored in a tuple element.
-    private static func strippedAttributedType(_ type: TypeSyntax) -> TypeSyntax {
-        if let attributed = type.as(AttributedTypeSyntax.self) {
-            return attributed.baseType
-        }
-        return type
     }
 
     static func appendValueToVariableExpression(

--- a/Sources/SmockMacro/Generator/VerifierGenerator.swift
+++ b/Sources/SmockMacro/Generator/VerifierGenerator.swift
@@ -477,12 +477,12 @@ extension VerifierGenerator {
 
         if parameters.count == 1 {
             let param = parameters[0]
-            let type = strippedParameterType(param, function: function)
+            let type = function.erasedTypeString(for: param.type)
             return "[\(type)]"
         } else {
             let tupleElements = parameters.map { param in
                 let name = (param.secondName ?? param.firstName).text
-                let type = strippedParameterType(param, function: function)
+                let type = function.erasedTypeString(for: param.type)
                 return "\(name): \(type)"
             }
             return "[(\(tupleElements.joined(separator: ", ")))]"
@@ -505,19 +505,6 @@ extension VerifierGenerator {
         }
     }
 
-    fileprivate static func strippedParameterType(
-        _ parameter: FunctionParameterSyntax,
-        function: MockableFunction
-    ) -> String {
-        // Strip attribute decorations (e.g. `inout`) before erasure.
-        let baseType: TypeSyntax
-        if let attributed = parameter.type.as(AttributedTypeSyntax.self) {
-            baseType = attributed.baseType
-        } else {
-            baseType = parameter.type
-        }
-        return function.erasedTypeString(for: baseType)
-    }
 }
 
 extension String {

--- a/Sources/SmockMacro/Utils/MockableFunction.swift
+++ b/Sources/SmockMacro/Utils/MockableFunction.swift
@@ -42,6 +42,12 @@ package struct MockableFunction {
     /// All generic parameters declared on the function, keyed by name.
     package let genericParameters: [String: GenericParameter]
 
+    /// Precomputed classifications, keyed by the trimmed description of each
+    /// parameter (after attribute stripping) and return type seen on the
+    /// declaration. ``classify(_:)`` is a lookup against this map, so each
+    /// type's syntax tree is walked exactly once during ``init``.
+    private let classifications: [String: ParameterClassification]
+
     /// The type conformance provider used to look up `additionalEquatableTypes`
     /// allowlist entries for non-generic parameters.
     ///
@@ -138,6 +144,46 @@ package struct MockableFunction {
         }
 
         self.genericParameters = genericParameters
+        self.classifications = Self.precomputeClassifications(
+            declaration: declaration,
+            genericParameters: genericParameters,
+            typeConformanceProvider: typeConformanceProvider
+        )
+    }
+
+    /// Walk every parameter type (after attribute stripping) and the return
+    /// type once, producing a lookup table that ``classify(_:)`` can consult.
+    ///
+    /// Multiple parameters can share the same stripped type (e.g.
+    /// `func foo(a: Int, b: Int)` or `func bar(x: T, y: T)`). The
+    /// classification depends only on the type, so the second computation
+    /// would be identical to the first and the duplicate is silently skipped.
+    private static func precomputeClassifications(
+        declaration: FunctionDeclSyntax,
+        genericParameters: [String: GenericParameter],
+        typeConformanceProvider: (String) -> TypeConformance
+    ) -> [String: ParameterClassification] {
+        var classifications: [String: ParameterClassification] = [:]
+        let genericNames = Set(genericParameters.keys)
+        let parameterTypes = declaration.signature.parameterClause.parameters.map {
+            Self.strippingAttributes($0.type)
+        }
+        for type in parameterTypes + [declaration.signature.returnClause?.type].compactMap({ $0 }) {
+            let key = type.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            // Multiple parameters can share the same stripped type (e.g.
+            // `func foo(a: Int, b: Int)` or `func bar(x: T, y: T)`). The
+            // classification depends only on the type, so the second computation
+            // would be identical to the first.
+            if classifications[key] == nil {
+                classifications[key] = computeClassification(
+                    for: type,
+                    genericParameters: genericParameters,
+                    genericNames: genericNames,
+                    typeConformanceProvider: typeConformanceProvider
+                )
+            }
+        }
+        return classifications
     }
 
     // MARK: - Parameter classification
@@ -155,22 +201,25 @@ package struct MockableFunction {
     }
 
     /// Classify a parameter type relative to this function's generic parameters.
+    ///
+    /// Looks the type up in the precomputed ``classifications`` map. Strips
+    /// `inout`/attribute decorations first, since callers may pass either the
+    /// raw `parameter.type` or an already-stripped form. Falls back to an
+    /// on-demand computation if the type wasn't seen at init time so the API
+    /// stays total, but every current caller passes a type from the function
+    /// declaration and hits the cache.
     package func classify(_ parameterType: TypeSyntax) -> ParameterClassification {
-        let typeString = parameterType.description.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Direct match: parameter type is exactly a generic parameter name.
-        if let parameter = genericParameters[typeString] {
-            return .directGeneric(parameter)
+        let stripped = Self.strippingAttributes(parameterType)
+        let key = stripped.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let cached = classifications[key] {
+            return cached
         }
-
-        // Wrapped match: type description contains a generic parameter name as a token.
-        for genericName in genericParameters.keys {
-            if Self.containsToken(genericName, in: typeString) {
-                return .wrappedGeneric
-            }
-        }
-
-        return .concrete
+        return Self.computeClassification(
+            for: stripped,
+            genericParameters: genericParameters,
+            genericNames: Set(genericParameters.keys),
+            typeConformanceProvider: typeConformanceProvider
+        )
     }
 
     // MARK: - Type erasure for generic substitution
@@ -211,31 +260,148 @@ package struct MockableFunction {
         }
     }
 
-    /// Check whether `token` appears in `text` as a complete identifier (not as a
-    /// substring of a longer identifier).
-    private static func containsToken(_ token: String, in text: String) -> Bool {
-        guard !token.isEmpty else { return false }
-        var searchStart = text.startIndex
-        while let range = text.range(of: token, range: searchStart..<text.endIndex) {
-            let beforeOK: Bool
-            if range.lowerBound == text.startIndex {
-                beforeOK = true
-            } else {
-                let prev = text[text.index(before: range.lowerBound)]
-                beforeOK = !prev.isLetter && !prev.isNumber && prev != "_"
+    /// Build a `GenericParameter` from a `some Constraint` type's constraint
+    /// expression. The constraint may be a single identifier (`some Encodable`)
+    /// or a protocol composition (`some Encodable & Sendable`).
+    private static func opaqueGenericParameter(
+        constraint: TypeSyntax,
+        typeConformanceProvider: (String) -> TypeConformance
+    ) -> GenericParameter {
+        // Extract the protocol name list from the constraint.
+        let protocols: [String]
+        if let composition = constraint.as(CompositionTypeSyntax.self) {
+            protocols = composition.elements.map { element in
+                element.type.description.trimmingCharacters(in: .whitespacesAndNewlines)
             }
-            let afterOK: Bool
-            if range.upperBound == text.endIndex {
-                afterOK = true
-            } else {
-                let next = text[range.upperBound]
-                afterOK = !next.isLetter && !next.isNumber && next != "_"
-            }
-            if beforeOK && afterOK {
-                return true
-            }
-            searchStart = range.upperBound
+        } else {
+            protocols = [
+                constraint.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            ]
         }
-        return false
+
+        let storageType: String
+        if protocols.isEmpty {
+            storageType = "Any"
+        } else {
+            storageType = "any " + protocols.joined(separator: " & ")
+        }
+
+        let isEquatable =
+            protocols.contains("Equatable")
+            || protocols.contains("Hashable")
+            || protocols.contains { proto in
+                typeConformanceProvider(proto) != .neitherComparableNorEquatable
+            }
+
+        return GenericParameter(storageType: storageType, isEquatable: isEquatable)
+    }
+
+    /// Strip `inout` (and any other `AttributedTypeSyntax`) decoration from a
+    /// parameter type so the underlying type can be classified and used as a
+    /// dictionary key.
+    private static func strippingAttributes(_ type: TypeSyntax) -> TypeSyntax {
+        if let attributed = type.as(AttributedTypeSyntax.self) {
+            return attributed.baseType
+        }
+        return type
+    }
+
+    /// Compute the classification for a single type. Called once per unique
+    /// parameter/return type during ``init`` to populate the cache, and as a
+    /// fallback from ``classify(_:)`` for types not seen at init time.
+    ///
+    /// Uses a single combined visitor pass to detect both `some` opaque types
+    /// nested inside the type and references to known generic parameter names.
+    private static func computeClassification(
+        for type: TypeSyntax,
+        genericParameters: [String: GenericParameter],
+        genericNames: Set<String>,
+        typeConformanceProvider: (String) -> TypeConformance
+    ) -> ParameterClassification {
+        // Top-level `some Constraint` is a direct opaque generic.
+        //
+        // `func foo(item: some Encodable & Sendable)` uses opaque type sugar
+        // that the Swift compiler implicitly desugars to an explicit generic
+        // parameter — but that desugaring happens *after* the macro runs, so
+        // the function declaration the macro sees has no
+        // `genericParameterClause` entry for it. We surface it here as a
+        // synthetic generic parameter.
+        if let opaque = type.as(SomeOrAnyTypeSyntax.self),
+            opaque.someOrAnySpecifier.tokenKind == .keyword(.some)
+        {
+            return .directGeneric(
+                opaqueGenericParameter(
+                    constraint: opaque.constraint,
+                    typeConformanceProvider: typeConformanceProvider
+                )
+            )
+        }
+
+        // Single walk that records both nested `some` opaques and any
+        // references to declared generic parameter names.
+        let analyzer = TypeAnalyzer(names: genericNames, viewMode: .sourceAccurate)
+        analyzer.walk(Syntax(type))
+
+        // Wrapped opaque, e.g. `Wrapper<some Constraint>` or `[some Constraint]`.
+        if analyzer.foundOpaque {
+            return .wrappedGeneric
+        }
+
+        // Direct match: parameter type is exactly a generic parameter name.
+        let typeString = type.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let parameter = genericParameters[typeString] {
+            return .directGeneric(parameter)
+        }
+
+        // Wrapped match: the type tree references a generic parameter name.
+        if analyzer.foundGenericNameReference {
+            return .wrappedGeneric
+        }
+
+        return .concrete
+    }
+}
+
+// MARK: - SyntaxVisitor
+
+/// Single-pass type-tree analyzer that records both:
+/// - whether the tree contains a `some Constraint` opaque type, and
+/// - whether the tree references any `IdentifierTypeSyntax` whose name is in
+///   the supplied generic-parameter-name set.
+///
+/// Skips the trailing `name` of `MemberTypeSyntax` so qualified member
+/// references like `MyModule.T` or `Optional<Foo.T>` are not treated as
+/// references to a generic parameter `T` declared on the function — only the
+/// `baseType` chain (and any generic argument clauses) is descended.
+private final class TypeAnalyzer: SyntaxVisitor {
+    let names: Set<String>
+    var foundOpaque = false
+    var foundGenericNameReference = false
+
+    init(names: Set<String>, viewMode: SyntaxTreeViewMode) {
+        self.names = names
+        super.init(viewMode: viewMode)
+    }
+
+    override func visit(_ node: SomeOrAnyTypeSyntax) -> SyntaxVisitorContinueKind {
+        if node.someOrAnySpecifier.tokenKind == .keyword(.some) {
+            self.foundOpaque = true
+        }
+        return .visitChildren
+    }
+
+    override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
+        if self.names.contains(node.name.text) {
+            self.foundGenericNameReference = true
+        }
+        return .visitChildren
+    }
+
+    override func visit(_ node: MemberTypeSyntax) -> SyntaxVisitorContinueKind {
+        self.walk(node.baseType)
+        if let genericArgumentClause = node.genericArgumentClause {
+            self.walk(genericArgumentClause)
+        }
+        return .skipChildren
     }
 }

--- a/Sources/Smockable/Docs.docc/GenericMethods.md
+++ b/Sources/Smockable/Docs.docc/GenericMethods.md
@@ -236,6 +236,37 @@ protocol Factory {
 > returns a value whose runtime type matches what the production code expects. A
 > mismatch produces a runtime force-cast failure inside the mock.
 
+## Opaque `some` Parameters
+
+Smockable also supports `some Constraint` opaque types in parameter position. They
+are semantically equivalent to the explicit-generic form and produce the same mock
+surface, so you can pick whichever reads more clearly in the protocol you are
+mirroring.
+
+```swift
+// Direct opaque — equivalent to `func process<T: Encodable & Sendable>(item: T)`
+@Smock
+protocol DirectOpaqueService {
+    func process(item: some Encodable & Sendable) async
+}
+
+// Wrapped opaque — equivalent to `func process<T: Sendable>(wrapper: GenericWrapper<T>)`
+@Smock
+protocol WrappedOpaqueService {
+    func process(wrapper: GenericWrapper<some Sendable>) async
+}
+```
+
+The matcher API and the choice of `matchingAs` / `exactAs` work the same way as for
+explicit generics — see the **Direct Generic Parameters** and **Wrapped Generic
+Parameters** sections above.
+
+> Note: This applies to parameter position only. Swift forbids `some` in the
+> return position of a protocol requirement (`func produce() -> some Encodable`
+> fails to compile with *"'some' type cannot be the return type of a protocol
+> requirement; did you mean to add an associated type?"*), so the case never
+> arises for `@Smock`-annotated protocols.
+
 ## Constraints
 
 > Note: Generic constraints **must** include `Sendable`. Mock state lives behind a `Mutex`

--- a/Tests/SmockMacroTests/GenericMethodsTests.swift
+++ b/Tests/SmockMacroTests/GenericMethodsTests.swift
@@ -65,6 +65,20 @@ protocol DirectGenericReturnService {
 }
 
 @Smock
+protocol DirectOpaqueGenericService {
+    /// Direct opaque generic: parameter is `some Constraint`. Equivalent to
+    /// `func process<T: Encodable & Sendable>(item: T)`.
+    func process(item: some Encodable & Sendable) async
+}
+
+@Smock
+protocol WrappedOpaqueGenericService {
+    /// Wrapped opaque generic: parameter wraps `some Constraint`. Equivalent
+    /// to `func process<T: Sendable>(wrapper: GenericWrapper<T>)`.
+    func process(wrapper: GenericWrapper<some Sendable>) async
+}
+
+@Smock
 protocol WrappedGenericReturnService {
     /// Wrapped generic return type: returns a wrapper containing the generic param.
     func produce<T: Sendable>(label: String) async -> GenericWrapper<T>
@@ -248,5 +262,103 @@ struct GenericMethodsTests {
         let mock = MockWrappedGenericReturnService(expectations: expectations)
         let result: GenericWrapper<Int> = await mock.produce(label: "x")
         #expect(result.value == 99)
+    }
+
+    // MARK: - Opaque `some` parameters
+    //
+    // These prove that `some Constraint` in parameter position generates the
+    // same mock surface as the explicit-generic form. The opaque-aware
+    // classification synthesizes an implicit generic parameter from each
+    // `some` occurrence and routes it through the same case 1 / case 2
+    // machinery as explicit generics.
+
+    @Test
+    func directOpaqueGenericWithAnyMatcher() async {
+        var expectations = MockDirectOpaqueGenericService.Expectations()
+        when(expectations.process(item: .any), times: 2, complete: .withSuccess)
+
+        let mock = MockDirectOpaqueGenericService(expectations: expectations)
+        await mock.process(item: "hello")
+        await mock.process(item: 42)
+
+        verify(mock, times: 2).process(item: .any)
+    }
+
+    @Test
+    func directOpaqueGenericWithMatchingAs() async {
+        var expectations = MockDirectOpaqueGenericService.Expectations()
+        when(
+            expectations.process(
+                item: .matchingAs(EquatablePayload.self) { payload in
+                    payload.id == "abc" && payload.count == 3
+                }
+            ),
+            complete: .withSuccess
+        )
+
+        let mock = MockDirectOpaqueGenericService(expectations: expectations)
+        await mock.process(item: EquatablePayload(id: "abc", count: 3))
+
+        verify(mock, times: 1).process(item: .any)
+    }
+
+    @Test
+    func directOpaqueGenericWithExactAs() async {
+        var expectations = MockDirectOpaqueGenericService.Expectations()
+        let expected = EquatablePayload(id: "abc", count: 3)
+        when(
+            expectations.process(item: .exactAs(expected)),
+            complete: .withSuccess
+        )
+
+        let mock = MockDirectOpaqueGenericService(expectations: expectations)
+        await mock.process(item: EquatablePayload(id: "abc", count: 3))
+
+        verify(mock, times: 1).process(item: .any)
+    }
+
+    @Test
+    func wrappedOpaqueGenericWithAnyMatcher() async {
+        var expectations = MockWrappedOpaqueGenericService.Expectations()
+        when(expectations.process(wrapper: .any), times: 2, complete: .withSuccess)
+
+        let mock = MockWrappedOpaqueGenericService(expectations: expectations)
+        await mock.process(wrapper: GenericWrapper(value: 1))
+        await mock.process(wrapper: GenericWrapper(value: "hello"))
+
+        verify(mock, times: 2).process(wrapper: .any)
+    }
+
+    @Test
+    func wrappedOpaqueGenericWithMatchingAs() async {
+        var expectations = MockWrappedOpaqueGenericService.Expectations()
+        when(
+            expectations.process(
+                wrapper: .matchingAs(GenericWrapper<Int>.self) { wrapper in
+                    wrapper.value == 42
+                }
+            ),
+            complete: .withSuccess
+        )
+
+        let mock = MockWrappedOpaqueGenericService(expectations: expectations)
+        await mock.process(wrapper: GenericWrapper(value: 42))
+
+        verify(mock, times: 1).process(wrapper: .any)
+    }
+
+    @Test
+    func wrappedOpaqueGenericWithExactAs() async {
+        var expectations = MockWrappedOpaqueGenericService.Expectations()
+        let expected = GenericWrapper(value: 42)
+        when(
+            expectations.process(wrapper: .exactAs(expected)),
+            complete: .withSuccess
+        )
+
+        let mock = MockWrappedOpaqueGenericService(expectations: expectations)
+        await mock.process(wrapper: GenericWrapper(value: 42))
+
+        verify(mock, times: 1).process(wrapper: .any)
     }
 }

--- a/Tests/SmockMacroTests/MockableFunctionTests.swift
+++ b/Tests/SmockMacroTests/MockableFunctionTests.swift
@@ -196,11 +196,12 @@ struct MockableFunctionTests {
         let function = try mockableFunction(source)
         let type = try parameterType(in: source, label: "item")
 
-        switch function.classify(type) {
+        let classification = function.classify(type)
+        switch classification {
         case .directGeneric(let info):
             #expect(info.storageType == "any Encodable & Sendable")
         default:
-            Issue.record("Expected directGeneric, got \(function.classify(type))")
+            Issue.record("Expected directGeneric, got \(classification)")
         }
     }
 
@@ -266,11 +267,12 @@ struct MockableFunctionTests {
         let function = try mockableFunction(source)
         let type = try parameterType(in: source, label: "item")
 
-        switch function.classify(type) {
+        let classification = function.classify(type)
+        switch classification {
         case .directGeneric(let info):
             #expect(info.storageType == "any Sendable")
         default:
-            Issue.record("Expected directGeneric for U")
+            Issue.record("Expected directGeneric, got \(classification)")
         }
     }
 
@@ -350,6 +352,199 @@ struct MockableFunctionTests {
             erased.description.trimmingCharacters(in: .whitespacesAndNewlines)
                 == type.description.trimmingCharacters(in: .whitespacesAndNewlines)
         )
+    }
+
+    // MARK: - Member-type qualified-name false positives (item 2)
+
+    @Test
+    func classifyDoesNotMatchGenericNameAsMemberOfQualifiedType() throws {
+        // `Outer.T` mentions a top-level type named `T` only as a *member*
+        // of `Outer`. The function's generic parameter `T` should not be
+        // treated as referenced here — the parameter is concrete.
+        let source = "func foo<T: Sendable>(item: T, holder: Outer.T)"
+        let function = try mockableFunction(source)
+        let holderType = try parameterType(in: source, label: "holder")
+
+        #expect(function.classify(holderType) == .concrete)
+    }
+
+    @Test
+    func classifyDoesNotMatchGenericNameAsGenericMemberOfQualifiedType() throws {
+        // `Outer.T<Int>` is a member type lookup with a generic argument; it
+        // should not match the function's generic parameter `T`.
+        let source = "func foo<T: Sendable>(item: T, holder: Outer.T<Int>)"
+        let function = try mockableFunction(source)
+        let holderType = try parameterType(in: source, label: "holder")
+
+        #expect(function.classify(holderType) == .concrete)
+    }
+
+    @Test
+    func classifyDoesNotMatchGenericNameInsideOptionalQualifiedType() throws {
+        // `Optional<Foo.T>` should not match `T` either.
+        let source = "func foo<T: Sendable>(item: T, holder: Optional<Foo.T>)"
+        let function = try mockableFunction(source)
+        let holderType = try parameterType(in: source, label: "holder")
+
+        #expect(function.classify(holderType) == .concrete)
+    }
+
+    @Test
+    func classifyMatchesGenericReferenceInBaseTypeOfMemberAccess() throws {
+        // `T.AssociatedType` references the function's generic parameter
+        // `T` as the base of a member access — this *should* still classify
+        // as wrappedGeneric.
+        let source = "func foo<T: Sendable>(item: T.AssociatedType)"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "item")
+
+        #expect(function.classify(type) == .wrappedGeneric)
+    }
+
+    // MARK: - Opaque `some` parameters (item 3)
+
+    @Test
+    func classifyDirectOpaqueParameterIsDirectGeneric() throws {
+        let source = "func foo(item: some Encodable & Sendable)"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "item")
+
+        let classification = function.classify(type)
+        switch classification {
+        case .directGeneric(let info):
+            #expect(info.storageType == "any Encodable & Sendable")
+            #expect(info.isEquatable == false)
+        default:
+            Issue.record("Expected directGeneric, got \(classification)")
+        }
+    }
+
+    @Test
+    func classifyDirectOpaqueWithSingleConstraintIsDirectGeneric() throws {
+        let source = "func foo(item: some Encodable)"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "item")
+
+        let classification = function.classify(type)
+        switch classification {
+        case .directGeneric(let info):
+            #expect(info.storageType == "any Encodable")
+        default:
+            Issue.record("Expected directGeneric, got \(classification)")
+        }
+    }
+
+    @Test
+    func classifyWrappedOpaqueParameterIsWrappedGeneric() throws {
+        let source = "func foo(input: PutItemInput<some Encodable & Sendable>)"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "input")
+
+        #expect(function.classify(type) == .wrappedGeneric)
+    }
+
+    @Test
+    func classifyOptionalOpaqueIsWrapped() throws {
+        let source = "func foo(item: (some Sendable)?)"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "item")
+
+        #expect(function.classify(type) == .wrappedGeneric)
+    }
+
+    @Test
+    func classifyArrayOfOpaqueIsWrapped() throws {
+        let source = "func foo(items: [some Sendable])"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "items")
+
+        #expect(function.classify(type) == .wrappedGeneric)
+    }
+
+    @Test
+    func classifyMixedExplicitAndOpaqueGenerics() throws {
+        let source = "func foo<T: Sendable>(named: T, item: some Encodable & Sendable)"
+        let function = try mockableFunction(source)
+
+        let namedType = try parameterType(in: source, label: "named")
+        let namedClassification = function.classify(namedType)
+        switch namedClassification {
+        case .directGeneric(let info):
+            #expect(info.storageType == "any Sendable")
+        default:
+            Issue.record("Expected directGeneric, got \(namedClassification)")
+        }
+
+        let itemType = try parameterType(in: source, label: "item")
+        let itemClassification = function.classify(itemType)
+        switch itemClassification {
+        case .directGeneric(let info):
+            #expect(info.storageType == "any Encodable & Sendable")
+        default:
+            Issue.record("Expected directGeneric, got \(itemClassification)")
+        }
+    }
+
+    @Test
+    func classifyOpaqueIsEquatableForEquatableConstraint() throws {
+        let source = "func foo(item: some Equatable & Sendable)"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "item")
+
+        let classification = function.classify(type)
+        switch classification {
+        case .directGeneric(let info):
+            #expect(info.isEquatable == true)
+        default:
+            Issue.record("Expected directGeneric, got \(classification)")
+        }
+    }
+
+    @Test
+    func classifyOpaqueRespectsAdditionalEquatableTypesAllowlist() throws {
+        let source = "func foo(item: some MyAllowlistedProtocol & Sendable)"
+        let function = try mockableFunction(
+            source,
+            equatableTypes: ["MyAllowlistedProtocol"]
+        )
+        let type = try parameterType(in: source, label: "item")
+
+        let classification = function.classify(type)
+        switch classification {
+        case .directGeneric(let info):
+            #expect(info.isEquatable == true)
+        default:
+            Issue.record("Expected directGeneric, got \(classification)")
+        }
+    }
+
+    @Test
+    func classifyAnyExistentialIsConcrete() throws {
+        // `any Encodable` is an existential, not a reference to a generic
+        // parameter, so it should classify as .concrete.
+        let source = "func foo(item: any Encodable)"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "item")
+
+        #expect(function.classify(type) == .concrete)
+    }
+
+    @Test
+    func erasedTypeStringForDirectOpaqueReturnsConstraintExistential() throws {
+        let source = "func foo(item: some Encodable & Sendable)"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "item")
+
+        #expect(function.erasedTypeString(for: type) == "any Encodable & Sendable")
+    }
+
+    @Test
+    func erasedTypeStringForWrappedOpaqueReturnsAnySendable() throws {
+        let source = "func foo(input: GenericWrapper<some Sendable>)"
+        let function = try mockableFunction(source)
+        let type = try parameterType(in: source, label: "input")
+
+        #expect(function.erasedTypeString(for: type) == "any Sendable")
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Walk the syntax tree for generic argument parsing. Support some types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
