### PR TITLE
Support .exact for case 1 generics.

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,394 @@
+# Smockable — Improvements Backlog
+
+This document tracks potential improvements and architectural changes for Smockable. Each
+entry notes whether the change is source-breaking (and therefore worth doing before 1.0)
+or purely additive (and can be added at any time).
+
+## 1.0 Considerations
+
+Before tagging 1.0, the public API surface gets locked in. Changes that would alter:
+
+- Generated type names (`Mock<Protocol>`, `Expectations`, `<Method>_FieldOptions`, etc.)
+- Method signatures on `Expectations` or the verifier
+- The `@Smock` macro parameters
+- Public matcher types (`ValueMatcher`, `ExistentialValueMatcher`)
+- The `when(...)` / `verify(...)` free functions
+
+become source-breaking after 1.0.
+
+### Before 1.0 — completed
+
+- **Generated `_InputMatcher` and `_ExpectedResponse` are now `internal`.** Both types are
+  generated without an explicit access modifier (defaulting to `internal`) regardless of
+  the protocol's access level. They're implementation details used by the public matcher
+  API but should never be referenced directly by users. Verified safe by searching across
+  known consumers (dynamo-db-tables, swift-local-containers, task-cluster) — no references
+  found. This preserves freedom to refactor matcher and response storage in the future.
+  `_FieldOptions` remains at the protocol's access
+  level because Swift's visibility chain requires it: it's returned from public methods
+  on `Expectations`.
+- **Collapsed seven matcher types into two: `ValueMatcher<T>` and
+  `ExistentialValueMatcher<T>`.** The original design had seven distinct enum
+  types (`ValueMatcher`, `OnlyEquatableValueMatcher`, `NonComparableValueMatcher`,
+  three `Optional*` variants, `ErasedValueMatcher`) with the macro selecting the
+  right type per parameter based on conformance. The new design uses two structs:
+  `ValueMatcher<T: Sendable>` for concrete parameters (with constraint-restricted
+  factory methods — `.exact()` requires `Equatable`, `.range()` requires
+  `Comparable`) and `ExistentialValueMatcher<T: Sendable>` for generic/existential
+  parameters (with `.matchingAs` and `.exactAs` for type-safe casting). The macro
+  generators now emit `ValueMatcher<T>` for concrete parameters and
+  `ExistentialValueMatcher<T>` for generic parameters based on the existing
+  `classify()` result — no conformance detection needed for matcher type selection.
+  The `additionalEquatableTypes` / `additionalComparableTypes` allowlists are no
+  longer needed for correctness (Swift's type system handles conformance at the
+  call site) but are retained as an ergonomic convenience for shorthand overload
+  generation.
+- **`MockableFunction.classify` switched from string-based to TypeSyntax-walking
+  identifier matching, and gained support for `some` opaque types in parameter
+  position.** Two visitors now drive parameter classification:
+  `GenericParameterReferenceFinder` walks a parameter type's syntax tree looking
+  for `IdentifierTypeSyntax` references to known generic parameter names while
+  skipping the trailing `name` of `MemberTypeSyntax` (so qualified member
+  references like `MyModule.T` or `Optional<Foo.T>` no longer produce false
+  positives), and `OpaqueSomeFinder` detects `SomeOrAnyTypeSyntax` nodes with
+  `some` specifier to recognize implicit generics introduced by opaque parameter
+  types. Direct opaque parameters (`func foo(item: some Encodable & Sendable)`)
+  classify as `.directGeneric` with the constraint existential as their storage
+  type, and wrapped opaque parameters (`func foo(input: PutItemInput<some
+  Encodable>)`) classify as `.wrappedGeneric` — equivalent to writing the
+  explicit generic form. Return-position `some` doesn't need handling because
+  Swift forbids `some` in the return position of a protocol requirement
+  (`func produce() -> some Encodable` fails to compile with *"'some' type
+  cannot be the return type of a protocol requirement; did you mean to add an
+  associated type?"*), so the case never reaches the macro. Closes IMPROVEMENTS
+  what was previously two separate backlog items describing the same fix from
+  different angles (qualified-name false positives, and `some` opaque parameter
+  support).
+- **Validated generic method API in real-world usage.** dynamo-db-tables
+  integrated the case 1 / case 2 split, `ExistentialValueMatcher`, and
+  `matchingAs` / `exactAs`. No ergonomics issues or naming concerns surfaced.
+  The typed-protocol refactor that originally motivated the work was reverted
+  (the Soto encoder flat-composition bug made it unnecessary), confirming that
+  the generic method support stands on its own.
+- **Documented `additionalEquatableTypes` / `additionalComparableTypes` as
+  convenience-only.** `MacroParameters.md` rewritten to clarify that the
+  allowlists control shorthand overload generation, not matcher correctness.
+  After the matcher collapse, Swift's type system handles conformance at the
+  call site — the allowlists are no longer needed for correctness.
+- **`.exact` overload for case-1 generics with Equatable constraint.** When a
+  direct generic parameter's constraint includes `Equatable` (or `Hashable`),
+  the macro now emits an additional overload on `Expectations` / the verifier
+  that takes a typed concrete value and delegates to `.exactAs(_:)` internally.
+  Lets test authors write `when(expectations.process(item: "hello"))` and
+  `verify(mock).process(item: "hello")` directly, instead of
+  `.exactAs("hello")`, for case-1 generic methods whose constraint allows
+  equality checking. Opted not to add a public `.exact` alias on
+  `ExistentialValueMatcher` — the generators emit `.exactAs` internally,
+  keeping the public matcher API single-named. Implemented as:
+  `AllParameterSequence` routes `isEquatable` case-1 parameters through
+  `.onlyEquatable` (producing both `.explicitMatcher` and `.exact` forms), and
+  both `FunctionStyleExpectationsGenerator` and `VerifierGenerator` emit a
+  `some <constraint>` parameter signature with `.exactAs(_)` as the matcher
+  initializer for the `.exact` form.
+
+## Improvement Backlog
+
+### 1. Generic method parsing edge cases
+
+**Status:** Mostly addressed — remaining items are speculative
+
+**Source-breaking?** No.
+
+**Description:**
+The main issue (opaque `some` parameter types) was fixed as part of the
+TypeSyntax-walking refactor (see "Before 1.0 — completed"). The remaining
+known edge case is same-type requirements in where clauses (e.g.
+`where T == String`), which Swift itself rejects on generic parameters
+("same-type requirement makes generic parameter 'T' non-generic"). No
+real-world failure has been reported for any remaining edge case.
+
+**Recommendation:** Close unless a concrete failure surfaces. The generic
+method parsing is well-tested via `MockableFunctionTests` (46 tests) and
+the end-to-end `GenericMethodsTests` (23 tests).
+
+---
+
+### 2. Argument capture API
+
+**Status:** Gap noted in framework comparison
+
+**Source-breaking?** No. Pure addition alongside existing verifier-return-value capture.
+
+**Description:**
+Other frameworks (Mockolo, Cuckoo, SwiftyMocky, Mockingbird) provide `ArgumentCaptor`
+APIs that allow registering a captor at expectation setup time and inspecting the captured
+values later. Smockable currently exposes captured arguments through the verifier return
+value (`verify(mock).foo(item: .any)` returns `[Item]`).
+
+The verifier-return approach is fine for most cases, but a captor API can be more
+ergonomic when:
+- Capturing across multiple invocations with different matchers
+- Capturing for use in subsequent assertions without rerunning verification
+- Capturing arguments from invocations where matching is done by other parameters
+
+**Possible API:**
+```swift
+let captor = ArgumentCaptor<String>()
+when(expectations.process(item: captor.matcher), complete: .withSuccess)
+
+// later
+let mock = MockStorage(expectations: expectations)
+await mock.process(item: "hello")
+await mock.process(item: "world")
+
+#expect(captor.values == ["hello", "world"])
+```
+
+**Open questions:**
+- Should captors be Sendable? (Probably yes — they need to work across actor boundaries.)
+- How do they interact with `times: N` constraints? Do they capture all matches or only
+  matches that satisfied the expectation?
+- How do they compose with `.matching` closures?
+
+---
+
+### 3. Diagnostic improvements
+
+**Status:** Partially complete
+
+**Source-breaking?** No.
+
+**Completed:**
+
+- **Generic constraint missing `Sendable`.** The macro now detects generic
+  parameters whose constraints don't include `Sendable` and emits a clear
+  error naming the specific parameter and function, instead of the user
+  getting an opaque Sendability error deep in macro output.
+- **`additionalEquatableTypes` / `additionalComparableTypes` parsing failures.**
+  Three new contextual diagnostics replace the generic `invalidMacroArguments`:
+  `missingArgumentLabel` (unlabeled arguments), `typeArrayExpected` (value
+  isn't an array), and `invalidTypeArrayElement` (unrecognized element
+  syntax, naming the specific element that failed).
+- **`TypeConformanceProvider` crash-on-bad-input.** Six `fatalError()` calls
+  in the type-string parser replaced with graceful fallback to
+  `.neitherComparableNorEquatable`. Malformed type syntax in the allowlists
+  no longer crashes the compiler — the user just loses convenience overloads
+  for that parameter.
+
+- **Warning on unparseable type strings.** When `TypeConformanceProvider` can't
+  parse a type string, it emits a warning diagnostic via `MacroExpansionContext`
+  naming the specific type string that failed, so the user knows why convenience
+  overloads are missing. `MacroExpansionContext` is now threaded from the macro
+  entry point through `MockGenerator` to the provider's warning handler.
+
+**Remaining:**
+
+- **Unsupported parameter forms.** When the macro can't generate matchers for a
+  parameter (e.g. function types, certain closure types), the failure mode is
+  opaque. A diagnostic detecting these at expansion time would save debugging.
+
+---
+
+### 4. Generic mock protocols beyond direct conformance
+
+**Status:** Idea — not investigated
+
+**Source-breaking?** Likely no, but unexplored.
+
+**Description:**
+Currently, the test author has to declare a "shadow" protocol with `@Smock` that mirrors
+the protocol they want to mock, including any generic methods. This works but causes
+friction:
+
+- Generic method signatures must be re-declared exactly
+- The `additionalEquatableTypes` allowlist applies only to the shadow protocol
+- If the original protocol changes, the shadow has to be updated manually
+
+A potential improvement: an `@Smock(mirroring: SomeProtocol.self)` form that takes the
+type to mirror as input and copies the requirements automatically. Likely runs into the
+same fundamental constraint of macros (can't introspect types from other modules), but
+might be feasible for protocols in the same module.
+
+**Open questions:**
+- Is this even possible with current macro capabilities?
+- How does it interact with associated types?
+- Would the friction reduction be worth the complexity?
+
+## Considered and Dropped
+
+Items that were originally on the backlog but, after concrete analysis, are not
+worth pursuing. Documented here so future readers don't re-litigate the same
+ground.
+
+### `@SmockSpecialize` annotation for case 2 generic methods
+
+**Original idea:** A `@SmockSpecialize` attribute on `@Smock` protocol methods
+that would let test authors substitute a concrete type (Form A) or a protocol
+existential (Form B) for a wrapped generic parameter, so the macro could emit
+richer per-parameter matchers instead of falling back to `ExistentialValueMatcher`.
+The two forms were intended to address case 2 verbosity at the expectation /
+verifier call site for protocols like
+`func putItem<T: Encodable & Sendable>(input: PutItemInput<T>)`.
+
+**Why dropped:** The original motivation — cleaner test authoring against case 2
+parameters — is now mostly addressed by the `matchingAs(_:_:)` and `exactAs(_:)`
+helpers on `ExistentialValueMatcher`. Test authors get a typed closure
+or typed exact value via:
+
+```swift
+when(
+    expectations.putItem(input: .matchingAs(PutItemInput<TestPayload>.self) { input in
+        input.tableName == "test-table" && input.item.id == "abc"
+    }),
+    complete: .withSuccess
+)
+
+when(
+    expectations.putItem(input: .exactAs(expectedInput)),
+    complete: .withSuccess
+)
+```
+
+The cast happens inside the framework. Failures return `false` from the matcher
+rather than crashing. Multiple test types in the same protocol work without any
+extra ceremony.
+
+The remaining things `@SmockSpecialize` would have offered on top of this are
+small: slightly cleaner call sites (no explicit type at every matcher use site),
+collections of wrapped generics with per-element protocol interface
+(`[PutItemInput<T>]` → `[any PutItemInputProtocol]`), and compile-time
+enforcement of the type assumption instead of a runtime cast that returns
+`false`. Of these, only the mixed-type-collection case is genuinely
+unaddressable by `matchingAs`/`exactAs`, and no real-world use case has
+surfaced for it. The ergonomic delta on the other two is too small to justify
+the macro infrastructure (substitution map plumbing, parsing two annotation
+forms, threading substituted types through six generators).
+
+If a user surfaces a real need for typed-element matching on collections of
+wrapped generics, this item is worth revisiting — likely as Form B only, since
+Form A's value collapses almost entirely into `matchingAs`/`exactAs`. The
+original two-form design notes are preserved in git history.
+
+### Parameter packs for matcher infrastructure
+
+**Original idea:** Replace the per-method generated `_InputMatcher` struct (and
+the per-method tuple-based invocation records, capture types, etc.) with a
+library-defined variadic generic shell using Swift 5.9 parameter packs:
+
+```swift
+struct InputMatcher<each Param: Sendable>: Sendable {
+    let matchers: (repeat ValueMatcher<each Param>)
+    func matches(_ args: repeat each Param) -> Bool { ... }
+}
+```
+
+The macro would emit per-method `typealias`es into this single library type
+instead of generating distinct struct definitions, with the goal of reducing
+the volume of generated code and unifying the verifier's tuple-construction
+codepaths.
+
+**Status: technically unblocked, deferred as low-priority.**
+
+The original blocker was matcher-type heterogeneity: smockable had seven
+distinct matcher types (previously seven, now collapsed to `ValueMatcher`
+and `ExistentialValueMatcher`),
+and a `(repeat ValueMatcher<each Param>)` pack requires a uniform element type.
+**If the matcher collapse lands** (collapsing the seven types into a single
+`ValueMatcher<T>` with constraint-restricted factories), this blocker is
+removed — `(repeat ValueMatcher<each Param>)` works because every parameter
+uses the same matcher type.
+
+A comparison with swift-mocking (which ships parameter packs successfully)
+confirmed that their architecture achieves packs via three design choices:
+a single uniform matcher type (`ArgMatcher<Argument>`), heterogeneous spy
+storage via `@dynamicMemberLookup`, and per-call-site generic specialization.
+Of these three, only the first (uniform matcher type) is a prerequisite for
+smockable-style packs; the other two are swift-mocking-specific architectural
+choices that smockable doesn't need to adopt. The matcher collapse provides
+the uniform type.
+
+**Why deferred rather than pursued:** the benefit is still purely
+macro-internal cleanliness — less generated code per protocol method, fewer
+string-templated per-parameter loops in the generators. The user-visible API
+(`Expectations` struct, `when(...)` / `verify(...)`, matcher factories) is
+completely unchanged. No test author's day gets better. The costs, while
+small, are nonzero:
+
+- **Parameter labels on `matches()` become positional.** Today the generated
+  `_InputMatcher` has `func matches(id: String, includeDeleted: Bool)` with
+  labels from the original protocol method. The library-defined pack version
+  has `func matches(_ values: repeat each Param)` — positional only, because
+  packs can't express labels. This is internal generated code that users never
+  see, but a transposed-argument bug in the generator would compile silently
+  where the labeled version would catch it.
+- **The verifier's capture-return-type tuples still need labels** (e.g.
+  `[(id: String, includeDeleted: Bool)]`), so half the generator's
+  string-building stays regardless.
+- **The pack type itself is ~50-100 lines of library code** that needs testing
+  and maintenance, partially offsetting the generated-code savings.
+
+**Recommendation:** defer until there's a concrete maintenance pain from
+per-method struct generation. If the macro's per-method code emission becomes a
+real burden (e.g., a new feature requires threading changes through every
+generated `_InputMatcher`), parameter packs provide a real solution and the
+path is clear. Until then, invest in user-visible improvements (`.exact()` for
+case 1 generics, argument capture, diagnostics). There is no API-breakage
+risk from doing this later — the change is entirely internal to macro output
+and library internals.
+
+## Notes on Test Coverage Measurement
+
+**The generator files in `Sources/SmockMacro/Generator/` will always show 0% coverage
+in Codecov reports.** This is a measurement artifact, not a real testing gap.
+
+Swift macros run inside a separate compiler plugin process that the Swift compiler
+invokes at build time. When the test runner executes, code coverage instrumentation
+attaches to the **test process**, not the macro plugin process. So even though every
+`@Smock`-annotated test protocol exercises the generators heavily during build, those
+executions are invisible to the coverage tool.
+
+The generators are tested **indirectly but exhaustively** via the macro-expanded mocks
+in `Tests/SmockMacroTests/`. Each `@Smock` annotation triggers the full generator
+pipeline, and the resulting mocks' behavior is asserted by the test cases. A bug in
+any generator codepath would surface as a test failure or compile error in those
+tests, even though Codecov reports the generator file at 0%.
+
+The only generator-side file that *can* show real coverage is
+`Sources/SmockMacro/Utils/MockableFunction.swift`, because `MockableFunctionTests.swift`
+imports `@testable SmockMacro` and exercises it directly from the test process. New
+package-level helpers added to the macro target should follow the same pattern: a
+direct unit test file in `Tests/SmockMacroTests/` so the helper isn't subject to the
+plugin-process coverage gap.
+
+**What NOT to do:**
+- Don't add lots of `assertMacroExpansion`-style tests purely to lift the coverage
+  number — they're brittle and add maintenance burden without catching bugs that the
+  existing behavior tests don't already catch.
+- Don't add a Codecov ignore for the generator files without first making sure the
+  team understands the rationale; the metric should be visibly low and explained,
+  not silently hidden.
+
+**What is reasonable:**
+- Add direct unit tests for any pure helpers that live in `Sources/SmockMacro/Utils/`
+  (e.g. `MockableFunction`, `TypeConformanceProvider`). These run in the test process
+  and contribute real coverage.
+- For generator code that's hard to exercise via mock-behavior tests (e.g. error
+  paths, edge cases in syntax handling), targeted `assertMacroExpansion` tests are
+  acceptable but should be the exception rather than the rule.
+
+## Notes on Source Stability
+
+**The package is 1.0-ready.** All pre-1.0 recommended items are completed:
+
+- The generic method API (case 1/2 distinction, `ExistentialValueMatcher`,
+  opaque `some` parameters) has been validated against dynamo-db-tables
+- The matcher collapse (`ValueMatcher<T>` + `ExistentialValueMatcher<T>`)
+  has been integrated and tested
+- The `additionalEquatableTypes` / `additionalComparableTypes` allowlists
+  have been documented as convenience-only
+- Diagnostics cover the most common failure modes (missing Sendable,
+  malformed type arrays, type-string parse failures)
+
+All remaining backlog items (`.exact()` for case 1 generics, argument
+capture, remaining diagnostics, generic mock protocols) are additive and
+can ship in 1.x releases without source breaks.

--- a/Sources/SmockMacro/Generator/AllParameterSequence.swift
+++ b/Sources/SmockMacro/Generator/AllParameterSequence.swift
@@ -36,12 +36,13 @@ enum AllParameterSequenceGenerator {
             let firstTypeConformance: TypeConformance
             switch function.classify(firstParameter.type) {
             case .directGeneric(let info):
-                // Direct generic: only .matching/.any are supported in the existential
-                // matcher. If the constraint includes Equatable, the .exact overload is
-                // generated separately as a typed wrapper, not via the parameter form
-                // pipeline (because the existential isn't itself Equatable).
-                firstTypeConformance = .neitherComparableNorEquatable
-                _ = info  // .exact handling is added separately
+                // Direct generic: `.any` / `.matching` are always supported via
+                // ExistentialValueMatcher. When the constraint includes Equatable
+                // we also emit a typed `.exact` shim that takes a concrete value
+                // and delegates to `.exactAs` internally — so the parameter form
+                // pipeline treats it like an onlyEquatable concrete parameter.
+                firstTypeConformance =
+                    info.isEquatable ? .onlyEquatable : .neitherComparableNorEquatable
             case .wrappedGeneric:
                 // Wrapped generic: only .any/.matching via ErasedValueMatcher.
                 firstTypeConformance = .neitherComparableNorEquatable

--- a/Sources/SmockMacro/Generator/FunctionStyleExpectationsGenerator.swift
+++ b/Sources/SmockMacro/Generator/FunctionStyleExpectationsGenerator.swift
@@ -132,6 +132,17 @@ enum FunctionStyleExpectationsGenerator {
 
         switch function.classify(parameter.type) {
         case .directGeneric(let info):
+            if case .exact = form {
+                // Constraint body without the leading `any ` — e.g.
+                // `any Equatable & Sendable` becomes `Equatable & Sendable`.
+                let constraintBody =
+                    info.storageType.hasPrefix("any ")
+                    ? String(info.storageType.dropFirst(4)) : info.storageType
+                return (
+                    "\(paramNameForSignature): some \(constraintBody)",
+                    "\(paramName): .exactAs(\(paramName))"
+                )
+            }
             return (
                 "\(paramNameForSignature): ExistentialValueMatcher<\(info.storageType)>",
                 "\(paramName): \(paramName)"

--- a/Sources/SmockMacro/Generator/VerifierGenerator.swift
+++ b/Sources/SmockMacro/Generator/VerifierGenerator.swift
@@ -161,10 +161,9 @@ enum VerifierGenerator {
         allParametersAreMatchers: Bool,
         function: MockableFunction
     )
-        -> (methodParameters: [String], methodInterpolationParameters: [String], matcherInitializers: [String])
+        -> (methodParameters: [String], matcherInitializers: [String])
     {
         var methodParameters: [String] = []
-        var methodInterpolationParameters: [String] = []
         var matcherInitializers: [String] = []
 
         for (parameter, parameterType, form) in parameterSequence {
@@ -176,11 +175,10 @@ enum VerifierGenerator {
                 function: function
             )
             methodParameters.append(fragments.paramDecl)
-            methodInterpolationParameters.append(fragments.interpolation)
             matcherInitializers.append(fragments.matcherInit)
         }
 
-        return (methodParameters, methodInterpolationParameters, matcherInitializers)
+        return (methodParameters, matcherInitializers)
     }
 
     private static func getWithLockCall(variablePrefix: String, storagePrefix: String) -> FunctionCallExprSyntax {
@@ -239,7 +237,7 @@ enum VerifierGenerator {
             partialResult = false
         }
 
-        let (methodParameters, methodInterpolationParameters, matcherInitializers) = getParameters(
+        let (methodParameters, matcherInitializers) = getParameters(
             parameterSequence: parameterSequence,
             allParametersAreMatchers: allParametersAreMatchers,
             function: function
@@ -247,7 +245,6 @@ enum VerifierGenerator {
 
         let methodSignature = methodParameters.joined(separator: ", ")
         let matcherInit = matcherInitializers.joined(separator: ", ")
-        let methodInterpolation = methodInterpolationParameters.joined(separator: ", ")
 
         let parameterList = functionDeclaration.signature.parameterClause.parameters
         let parameters = Array(parameterList)
@@ -259,7 +256,6 @@ enum VerifierGenerator {
         let variablePrefix = VariablePrefixGenerator.text(for: functionDeclaration)
         let inputMatcherType = "\(typePrefix)\(variablePrefix.capitalizingComponentsFirstLetter())_InputMatcher"
         let functionName = functionDeclaration.name.text
-        let functionInterpolationSignature = "\(functionName)(\(methodInterpolation))"
 
         let returnTypeString = captureReturnType(parameters: parameters, function: function)!
         let mapExpression = captureMapExpression(parameters: parameters)!
@@ -274,6 +270,21 @@ enum VerifierGenerator {
                 """
             )
         }
+
+        // Interpolation is only consumed by the verification-message path below,
+        // which runs only when every parameter is an explicit matcher. Computing
+        // it here (rather than alongside the paramDecl/matcherInit fragments)
+        // keeps `parameterFragments` honest: callers that don't reach this branch
+        // never see a bogus interpolation field.
+        let methodInterpolation = parameterSequence.map { parameter, _, _ in
+            interpolationFragment(
+                parameter: parameter,
+                allParametersAreMatchers: allParametersAreMatchers,
+                function: function
+            )
+        }
+        .joined(separator: ", ")
+        let functionInterpolationSignature = "\(functionName)(\(methodInterpolation))"
 
         return try FunctionDeclSyntax(
             "@discardableResult \(raw: accessLevel.rawValue) func \(raw: functionName)(\(raw: methodSignature)) -> \(raw: returnTypeString)"
@@ -345,29 +356,44 @@ enum VerifierGenerator {
 }
 
 extension VerifierGenerator {
-    /// Build the (param decl, interpolation, matcher init) fragments for a single
-    /// verifier parameter, taking generic substitution into account. Lives in the
+    /// Build the (param decl, matcher init) fragments for a single verifier
+    /// parameter, taking generic substitution into account. Lives in the
     /// extension to keep the main type body within size limits.
+    ///
+    /// Interpolation is computed separately by ``interpolationFragment(parameter:allParametersAreMatchers:function:)``
+    /// and only on the code path that actually emits a verification-message string
+    /// (the all-matchers body). Keeping it out of this tuple prevents shim-path
+    /// callers from having to invent a placeholder that would never compile against
+    /// their parameter types.
     fileprivate static func parameterFragments(
         parameter: FunctionParameterSyntax,
         parameterType: TypeConformance,
         form: AllParameterSequenceGenerator.ParameterForm,
         allParametersAreMatchers: Bool,
         function: MockableFunction
-    ) -> (paramDecl: String, interpolation: String, matcherInit: String) {
+    ) -> (paramDecl: String, matcherInit: String) {
         let names = parameterNames(parameter, allParametersAreMatchers: allParametersAreMatchers)
 
         switch function.classify(parameter.type) {
         case .directGeneric(let info):
+            if case .exact = form {
+                // Constraint body without the leading `any ` — e.g.
+                // `any Equatable & Sendable` becomes `Equatable & Sendable`.
+                let constraintBody =
+                    info.storageType.hasPrefix("any ")
+                    ? String(info.storageType.dropFirst(4)) : info.storageType
+                return (
+                    "\(names.signature): some \(constraintBody)",
+                    "\(names.matcherPrefix).exactAs(\(names.local))"
+                )
+            }
             return (
                 "\(names.signature): ExistentialValueMatcher<\(info.storageType)>",
-                "\(names.signature): \\(\(names.local).description)",
                 "\(names.matcherPrefix)\(names.local)"
             )
         case .wrappedGeneric:
             return (
                 "\(names.signature): ExistentialValueMatcher<any Sendable>",
-                "\(names.signature): \\(\(names.local).description)",
                 "\(names.matcherPrefix)\(names.local)"
             )
         case .concrete:
@@ -377,6 +403,28 @@ extension VerifierGenerator {
                 form: form,
                 names: names
             )
+        }
+    }
+
+    /// Build the verification-message interpolation fragment for a single
+    /// parameter. Only called on the all-matchers code path, where every
+    /// `names.local` refers to a matcher value whose `.description` /
+    /// `.stringSpecficDescription` is guaranteed to exist.
+    fileprivate static func interpolationFragment(
+        parameter: FunctionParameterSyntax,
+        allParametersAreMatchers: Bool,
+        function: MockableFunction
+    ) -> String {
+        let names = parameterNames(parameter, allParametersAreMatchers: allParametersAreMatchers)
+        switch function.classify(parameter.type) {
+        case .concrete:
+            let paramType = parameter.type.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            if paramType == "String" || paramType == "String?" {
+                return "\(names.signature): \\(\(names.local).stringSpecficDescription)"
+            }
+            return "\(names.signature): \\(\(names.local).description)"
+        case .directGeneric, .wrappedGeneric:
+            return "\(names.signature): \\(\(names.local).description)"
         }
     }
 
@@ -416,35 +464,25 @@ extension VerifierGenerator {
         parameterType: TypeConformance,
         form: AllParameterSequenceGenerator.ParameterForm,
         names: ParameterNames
-    ) -> (paramDecl: String, interpolation: String, matcherInit: String) {
+    ) -> (paramDecl: String, matcherInit: String) {
         let paramType = parameter.type.description.trimmingCharacters(in: .whitespacesAndNewlines)
         let isOptional = paramType.hasSuffix("?")
-
-        let interpolation: String
-        if paramType == "String" || paramType == "String?" {
-            interpolation = "\(names.signature): \\(\(names.local).stringSpecficDescription)"
-        } else {
-            interpolation = "\(names.signature): \\(\(names.local).description)"
-        }
 
         switch form {
         case .range:
             let baseType = isOptional ? String(paramType.dropLast()) : paramType
             return (
                 "\(names.signature): ClosedRange<\(baseType)>",
-                interpolation,
                 "\(names.matcherPrefix).range(\(names.local))"
             )
         case .explicitMatcher:
             return (
                 "\(names.signature): ValueMatcher<\(paramType)>",
-                interpolation,
                 "\(names.matcherPrefix)\(names.local)"
             )
         case .exact:
             return (
                 "\(names.signature): \(paramType)",
-                interpolation,
                 "\(names.matcherPrefix).exact(\(names.local))"
             )
         }

--- a/Sources/SmockMacro/Generator/VerifierGenerator.swift
+++ b/Sources/SmockMacro/Generator/VerifierGenerator.swift
@@ -290,9 +290,10 @@ enum VerifierGenerator {
     /// Bundle of values shared between the two verifier-body codepaths,
     /// introduced so the builders don't accumulate a long parameter list.
     private struct MethodBuildContext {
-        let parameterSequence: [(
-            FunctionParameterSyntax, TypeConformance, AllParameterSequenceGenerator.ParameterForm
-        )]
+        let parameterSequence:
+            [(
+                FunctionParameterSyntax, TypeConformance, AllParameterSequenceGenerator.ParameterForm
+            )]
         let methodSignature: String
         let matcherInit: String
         let matcherCall: String
@@ -323,7 +324,8 @@ enum VerifierGenerator {
         }
         .joined(separator: ", ")
         let functionInterpolationSignature = "\(context.functionName)(\(methodInterpolation))"
-        let declaration = "@discardableResult \(context.accessLevel.rawValue)"
+        let declaration =
+            "@discardableResult \(context.accessLevel.rawValue)"
             + " func \(context.functionName)(\(context.methodSignature))"
             + " -> \(context.returnTypeString)"
 

--- a/Sources/SmockMacro/Generator/VerifierGenerator.swift
+++ b/Sources/SmockMacro/Generator/VerifierGenerator.swift
@@ -271,24 +271,63 @@ enum VerifierGenerator {
             )
         }
 
-        // Interpolation is only consumed by the verification-message path below,
-        // which runs only when every parameter is an explicit matcher. Computing
-        // it here (rather than alongside the paramDecl/matcherInit fragments)
-        // keeps `parameterFragments` honest: callers that don't reach this branch
-        // never see a bogus interpolation field.
-        let methodInterpolation = parameterSequence.map { parameter, _, _ in
+        let context = MethodBuildContext(
+            parameterSequence: parameterSequence,
+            methodSignature: methodSignature,
+            matcherInit: matcherInit,
+            matcherCall: matcherCall,
+            inputMatcherType: inputMatcherType,
+            functionName: functionName,
+            variablePrefix: variablePrefix,
+            storagePrefix: storagePrefix,
+            accessLevel: accessLevel,
+            returnTypeString: returnTypeString,
+            mapExpression: mapExpression
+        )
+        return try fullVerifierBody(context: context, function: function)
+    }
+
+    /// Bundle of values shared between the two verifier-body codepaths,
+    /// introduced so the builders don't accumulate a long parameter list.
+    private struct MethodBuildContext {
+        let parameterSequence: [(
+            FunctionParameterSyntax, TypeConformance, AllParameterSequenceGenerator.ParameterForm
+        )]
+        let methodSignature: String
+        let matcherInit: String
+        let matcherCall: String
+        let inputMatcherType: String
+        let functionName: String
+        let variablePrefix: String
+        let storagePrefix: String
+        let accessLevel: AccessLevel
+        let returnTypeString: String
+        let mapExpression: String
+    }
+
+    /// Builds the full (all-matchers) verifier method body that performs the
+    /// invocation filter and calls `performVerification`. Split out of
+    /// ``generateMethodForCombination`` to keep that function under the body
+    /// length limit and to localize the interpolation computation that only
+    /// matters on this path.
+    private static func fullVerifierBody(
+        context: MethodBuildContext,
+        function: MockableFunction
+    ) throws -> FunctionDeclSyntax {
+        let methodInterpolation = context.parameterSequence.map { parameter, _, _ in
             interpolationFragment(
                 parameter: parameter,
-                allParametersAreMatchers: allParametersAreMatchers,
+                allParametersAreMatchers: true,
                 function: function
             )
         }
         .joined(separator: ", ")
-        let functionInterpolationSignature = "\(functionName)(\(methodInterpolation))"
+        let functionInterpolationSignature = "\(context.functionName)(\(methodInterpolation))"
+        let declaration = "@discardableResult \(context.accessLevel.rawValue)"
+            + " func \(context.functionName)(\(context.methodSignature))"
+            + " -> \(context.returnTypeString)"
 
-        return try FunctionDeclSyntax(
-            "@discardableResult \(raw: accessLevel.rawValue) func \(raw: functionName)(\(raw: methodSignature)) -> \(raw: returnTypeString)"
-        ) {
+        return try FunctionDeclSyntax("\(raw: declaration)") {
             VariableDeclSyntax(
                 bindingSpecifier: .keyword(.let),
                 bindings: PatternBindingListSyntax([
@@ -297,7 +336,10 @@ enum VerifierGenerator {
                         initializer: InitializerClauseSyntax(
                             equal: .equalToken(),
                             value: ExprSyntax(
-                                getWithLockCall(variablePrefix: variablePrefix, storagePrefix: storagePrefix)
+                                getWithLockCall(
+                                    variablePrefix: context.variablePrefix,
+                                    storagePrefix: context.storagePrefix
+                                )
                             )
                         )
                     )
@@ -306,26 +348,26 @@ enum VerifierGenerator {
 
             DeclSyntax(
                 """
-                let matcher = \(raw: inputMatcherType)(\(raw: matcherInit))
+                let matcher = \(raw: context.inputMatcherType)(\(raw: context.matcherInit))
                 """
             )
 
             DeclSyntax(
                 """
                 let matchingInvocations = invocations.filter { invocation in
-                    matcher.matches(\(raw: matcherCall))
+                    matcher.matches(\(raw: context.matcherCall))
                 }
                 """
             )
 
             getVerificationCall(
-                storagePrefix: storagePrefix,
+                storagePrefix: context.storagePrefix,
                 functionInterpolationSignature: functionInterpolationSignature
             )
 
             ReturnStmtSyntax(
                 returnKeyword: .keyword(.return, leadingTrivia: .newline),
-                expression: ExprSyntax("\(raw: mapExpression)")
+                expression: ExprSyntax("\(raw: context.mapExpression)")
             )
         }
     }

--- a/Sources/Smockable/Docs.docc/GenericMethods.md
+++ b/Sources/Smockable/Docs.docc/GenericMethods.md
@@ -89,6 +89,30 @@ If the production code calls the method with a value that isn't a `UserPayload`,
 the cast inside `matchingAs` / `exactAs` returns `false` and the matcher simply
 doesn't match — it never crashes.
 
+When the generic constraint itself includes `Equatable` (or `Hashable`, which
+implies `Equatable`), Smockable generates an additional overload that accepts
+the concrete value directly — no `.exactAs(_:)` needed at the call site:
+
+```swift
+@Smock
+protocol Tagger {
+    func tag<T: Equatable & Sendable>(value: T) async
+}
+
+@Test func tagExact() async {
+    var expectations = MockTagger.Expectations()
+    when(expectations.tag(value: "hello"), complete: .withSuccess)
+
+    let mock = MockTagger(expectations: expectations)
+    await mock.tag(value: "hello")
+
+    verify(mock, times: 1).tag(value: "hello")
+}
+```
+
+The overload is a thin shim that calls `.exactAs` internally, so the matching
+semantics — runtime cast, returns `false` on type mismatch — are identical.
+
 If you'd rather write the cast inline, the unwrapped form is still available:
 
 ```swift
@@ -270,9 +294,11 @@ Parameters** sections above.
 > and must be `Sendable`-conforming. The generated code will fail to compile if your
 > generic parameter doesn't include `Sendable`.
 
-Several matchers available for non-generic methods (`.exact()`, range, `update(value:)`)
-are not available for parameters or return types that reference a generic parameter. See
-<doc:FrameworkLimitations> for the full list and rationale.
+Some matchers available for non-generic methods (range, `update(value:)`) are not
+available for parameters or return types that reference a generic parameter.
+The `.exact` form is available for *direct* generic parameters when the constraint
+includes `Equatable` or `Hashable`, as described above; it's not yet available for
+wrapped generics. See <doc:FrameworkLimitations> for the full list and rationale.
 
 ## See Also
 

--- a/Tests/SmockMacroTests/GenericMethodsTests.swift
+++ b/Tests/SmockMacroTests/GenericMethodsTests.swift
@@ -84,6 +84,30 @@ protocol WrappedGenericReturnService {
     func produce<T: Sendable>(label: String) async -> GenericWrapper<T>
 }
 
+@Smock
+protocol EquatableDirectGenericService {
+    /// Direct generic with Equatable constraint — enables the typed `.exact` form.
+    func process<T: Equatable & Sendable>(item: T) async
+    /// Direct generic with Hashable constraint — Hashable implies Equatable.
+    func consume<T: Hashable & Sendable>(key: T) async
+}
+
+@Smock
+protocol EquatableDirectOpaqueGenericService {
+    /// Direct opaque generic with Equatable constraint.
+    func process(item: some Equatable & Sendable) async
+}
+
+@Smock
+protocol MixedEquatableDirectGenericService {
+    /// Two direct generics, one Equatable and one not — verifies the exact form
+    /// is emitted per-parameter, independently.
+    func process<T: Equatable & Sendable, U: Encodable & Sendable>(
+        equatable: T,
+        other: U
+    ) async
+}
+
 // MARK: - Tests
 
 struct GenericMethodsTests {
@@ -360,5 +384,92 @@ struct GenericMethodsTests {
         await mock.process(wrapper: GenericWrapper(value: 42))
 
         verify(mock, times: 1).process(wrapper: .any)
+    }
+
+    // MARK: - Direct generic `.exact` form (Equatable constraint)
+    //
+    // When a case-1 direct generic parameter's constraint includes Equatable
+    // (or Hashable), the macro emits an additional overload that accepts a
+    // concrete typed value and delegates to `.exactAs` internally. This lets
+    // users write `when(expectations.process(item: "hello"))` instead of
+    // `.exactAs("hello")`.
+
+    @Test
+    func equatableDirectGenericExactFormWhen() async {
+        var expectations = MockEquatableDirectGenericService.Expectations()
+        when(expectations.process(item: "hello"), complete: .withSuccess)
+
+        let mock = MockEquatableDirectGenericService(expectations: expectations)
+        await mock.process(item: "hello")
+
+        verify(mock, times: 1).process(item: .any)
+    }
+
+    @Test
+    func equatableDirectGenericExactFormVerify() async {
+        var expectations = MockEquatableDirectGenericService.Expectations()
+        when(expectations.process(item: .any), times: 2, complete: .withSuccess)
+
+        let mock = MockEquatableDirectGenericService(expectations: expectations)
+        await mock.process(item: "hello")
+        await mock.process(item: 42)
+
+        verify(mock, times: 1).process(item: "hello")
+        verify(mock, times: 1).process(item: 42)
+    }
+
+    @Test
+    func equatableDirectGenericExactDoesNotMatchDifferentConcreteType() async {
+        // `.exact(item: "hello")` should cast to String at match time; a
+        // non-String call with the same underlying representation shouldn't match.
+        var expectations = MockEquatableDirectGenericService.Expectations()
+        when(expectations.process(item: .any), complete: .withSuccess)
+
+        let mock = MockEquatableDirectGenericService(expectations: expectations)
+        await mock.process(item: 42)
+
+        verify(mock, .never).process(item: "42")
+        verify(mock, times: 1).process(item: 42)
+    }
+
+    @Test
+    func hashableDirectGenericExactForm() async {
+        var expectations = MockEquatableDirectGenericService.Expectations()
+        when(expectations.consume(key: "k"), complete: .withSuccess)
+
+        let mock = MockEquatableDirectGenericService(expectations: expectations)
+        await mock.consume(key: "k")
+
+        verify(mock, times: 1).consume(key: "k")
+    }
+
+    @Test
+    func equatableDirectOpaqueGenericExactForm() async {
+        var expectations = MockEquatableDirectOpaqueGenericService.Expectations()
+        when(expectations.process(item: "hello"), complete: .withSuccess)
+
+        let mock = MockEquatableDirectOpaqueGenericService(expectations: expectations)
+        await mock.process(item: "hello")
+
+        verify(mock, times: 1).process(item: "hello")
+    }
+
+    @Test
+    func mixedEquatableDirectGenericExactFormOnEquatableParam() async {
+        // The Equatable parameter gets an exact overload; the non-Equatable one
+        // still requires an ExistentialValueMatcher. Both are independently
+        // selectable, so we expect overloads covering (exact, matcher),
+        // (matcher, matcher), and (matcher, matcher) combinations — the one
+        // exercised here is (exact, .any).
+        var expectations = MockMixedEquatableDirectGenericService.Expectations()
+        when(
+            expectations.process(equatable: "tag", other: .any),
+            complete: .withSuccess
+        )
+
+        let mock = MockMixedEquatableDirectGenericService(expectations: expectations)
+        await mock.process(equatable: "tag", other: 123)
+
+        verify(mock, times: 1).process(equatable: "tag", other: .any)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Support .exact for case 1 generics.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
