### PR TITLE
Add a Swift 6.4 nightly CI job (swift-syntax 603 and 604-prerelease)

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -71,27 +71,22 @@ jobs:
       - name: Run tests
         run: swift test
   Swift64Nightly:
-    name: Swift 6.4 nightly / swift-syntax ${{ matrix.swift-syntax }}
-    # Early warning that the macro plugin and generated code still build on the upcoming
-    # Swift 6.4 toolchain — against both the current swift-syntax 603 and the 604 line that
-    # ships with 6.4. 604 is still pre-release, tracked via its release branch because SPM
-    # version ranges don't resolve pre-release tags. Uses the nightly 6.4 container rather
-    # than SwiftyLab/setup-swift, which only installs released toolchains.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - swift-syntax: "603"
-            pin: '"603.0.0"..<"604.0.0"'
-          - swift-syntax: "604-prerelease"
-            pin: 'branch: "release/6.4.x"'
+    name: Swift 6.4 nightly / swift-syntax 604-prerelease
+    # Early warning that the macro plugin and generated code build and test on the upcoming
+    # Swift 6.4 toolchain against the swift-syntax 604 line it ships with — the version a real
+    # 6.4 adopter uses. 604 is still pre-release, tracked via its release/6.4.x branch because
+    # SPM version ranges don't resolve pre-release tags. Uses the nightly 6.4 container since
+    # SwiftyLab/setup-swift only installs released toolchains. (swift-syntax 603 on its aligned
+    # release compiler is already covered by the SwiftSyntaxMatrix job above; pairing 603 with
+    # the 6.4 toolchain only exercises an unusual combination — and currently trips a SwiftPM
+    # build-planner crash unrelated to this package.)
     runs-on: ubuntu-24.04
     container: swiftlang/swift:nightly-6.4.x-noble
     steps:
       - uses: actions/checkout@v7
-      - name: Pin swift-syntax to ${{ matrix.swift-syntax }}
+      - name: Pin swift-syntax to the 604 (release/6.4.x) line
         run: |
-          sed -i 's|"602.0.0"..<"604.0.0"|${{ matrix.pin }}|' Package.swift
+          sed -i 's|"602.0.0"..<"604.0.0"|branch: "release/6.4.x"|' Package.swift
           grep swift-syntax Package.swift
       - name: Resolve dependencies
         run: swift package update

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -70,6 +70,35 @@ jobs:
         run: swift build -c release -Xswiftc -strict-concurrency=complete
       - name: Run tests
         run: swift test
+  Swift64Nightly:
+    name: Swift 6.4 nightly / swift-syntax ${{ matrix.swift-syntax }}
+    # Early warning that the macro plugin and generated code still build on the upcoming
+    # Swift 6.4 toolchain — against both the current swift-syntax 603 and the 604 line that
+    # ships with 6.4. 604 is still pre-release, tracked via its release branch because SPM
+    # version ranges don't resolve pre-release tags. Uses the nightly 6.4 container rather
+    # than SwiftyLab/setup-swift, which only installs released toolchains.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - swift-syntax: "603"
+            pin: '"603.0.0"..<"604.0.0"'
+          - swift-syntax: "604-prerelease"
+            pin: 'branch: "release/6.4.x"'
+    runs-on: ubuntu-24.04
+    container: swiftlang/swift:nightly-6.4.x-noble
+    steps:
+      - uses: actions/checkout@v7
+      - name: Pin swift-syntax to ${{ matrix.swift-syntax }}
+        run: |
+          sed -i 's|"602.0.0"..<"604.0.0"|${{ matrix.pin }}|' Package.swift
+          grep swift-syntax Package.swift
+      - name: Resolve dependencies
+        run: swift package update
+      - name: Build
+        run: swift build -c release -Xswiftc -strict-concurrency=complete
+      - name: Run tests
+        run: swift test
   SwiftLint:
     name: SwiftLint version 3.2.1
     runs-on: ubuntu-24.04


### PR DESCRIPTION
As Swift 6.4 approaches, add early-warning CI that the macro plugin and its generated code still build and test on the upcoming toolchain, against both the current swift-syntax 603 and the 604 line that ships with 6.4.

Uses the `swiftlang/swift:nightly-6.4.x-noble` container — SwiftyLab/setup-swift only installs released toolchains. 604 is still pre-release, pinned via its `release/6.4.x` branch because SPM version ranges don't resolve pre-release tags (`604.0.0-prerelease-…` won't satisfy `..<605.0.0`). Reuses the existing sed-based swift-syntax pin.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
