### PR TITLE
Qualify generated SourceLocation via module selector; require Swift 6.3

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        swift-version: ["6.3.3", "6.2.4"]
+        swift-version: ["6.3.3"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         swift-version: ["6.3.3"]
-        swift-syntax-major: ["602", "603"]
+        swift-syntax-major: ["603"]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -62,7 +62,7 @@ jobs:
         # sed needs to follow.
         run: |
           next=$((${{ matrix.swift-syntax-major }} + 1))
-          sed -i 's|"602.0.0"..<"604.0.0"|"${{ matrix.swift-syntax-major }}.0.0"..<"'${next}'.0.0"|' Package.swift
+          sed -i 's|"603.0.0"..<"604.0.0"|"${{ matrix.swift-syntax-major }}.0.0"..<"'${next}'.0.0"|' Package.swift
           grep swift-syntax Package.swift
       - name: Resolve dependencies
         run: swift package update
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Pin swift-syntax to the 604 (release/6.4.x) line
         run: |
-          sed -i 's|"602.0.0"..<"604.0.0"|branch: "release/6.4.x"|' Package.swift
+          sed -i 's|"603.0.0"..<"604.0.0"|branch: "release/6.4.x"|' Package.swift
           grep swift-syntax Package.swift
       - name: Resolve dependencies
         run: swift package update

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.2
+// swift-tools-version:6.3
 
 import CompilerPluginSupport
 import Foundation
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", "602.0.0"..<"604.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax", "603.0.0"..<"604.0.0")
     ],
     targets: [
         .macro(

--- a/Sources/SmockMacro/Generator/MockGenerator.swift
+++ b/Sources/SmockMacro/Generator/MockGenerator.swift
@@ -235,7 +235,7 @@ enum MockGenerator {
             let verifierSig =
                 nonisolatedPrefix + parameters.accessLevel.rawValue
                 + " func getVerifier(mode: VerificationMode,"
-                + " sourceLocation: SourceLocation, inOrder: InOrder?) -> Verifier {"
+                + " sourceLocation: Testing::SourceLocation, inOrder: InOrder?) -> Verifier {"
             try FunctionDeclSyntax("\(raw: verifierSig)") {
                 ReturnStmtSyntax(
                     expression: ExprSyntax(

--- a/Sources/SmockMacro/Generator/StorageGenerator.swift
+++ b/Sources/SmockMacro/Generator/StorageGenerator.swift
@@ -259,7 +259,7 @@ enum StorageGenerator {
         // Function with no parameters
         return try FunctionDeclSyntax(
             """
-            \(raw: nonisolatedPrefix)\(raw: accessLevel.rawValue) func verifyNoInteractions(sourceLocation: SourceLocation) {
+            \(raw: nonisolatedPrefix)\(raw: accessLevel.rawValue) func verifyNoInteractions(sourceLocation: Testing::SourceLocation) {
                 let combinedCallCount = self.state.mutex.withLock { storage in
                     return storage.combinedCallCount
                 }

--- a/Sources/SmockMacro/Generator/VerifierGenerator.swift
+++ b/Sources/SmockMacro/Generator/VerifierGenerator.swift
@@ -46,7 +46,7 @@ enum VerifierGenerator {
 
                 try VariableDeclSyntax(
                     """
-                    private let sourceLocation: SourceLocation
+                    private let sourceLocation: Testing::SourceLocation
                     """
                 )
 
@@ -65,7 +65,7 @@ enum VerifierGenerator {
                 }
 
                 try InitializerDeclSyntax(
-                    "init(state: State, mode: VerificationMode, sourceLocation: SourceLocation, inOrder: InOrder?) {"
+                    "init(state: State, mode: VerificationMode, sourceLocation: Testing::SourceLocation, inOrder: InOrder?) {"
                 ) {
                     ExprSyntax("self.state = state")
                     ExprSyntax("self.mode = mode")


### PR DESCRIPTION
The @Smock macro emitted a bare `SourceLocation` in the generated verifier (getVerifier, verifyNoInteractions, the Verifier's stored property + init). In a test file that only imports Testing it resolves fine, but it collides with any other imported module that also exports a `SourceLocation` (e.g. swift-wire's introspection `Wire.SourceLocation`), giving "'SourceLocation' is ambiguous for type lookup" at the expansion site.

Generated code should name external types so they can't be captured by names in the user's scope. Use the SE-0491 module selector `Testing::SourceLocation` — stronger than `Testing.SourceLocation`, which member-access could still shadow with a type named `Testing`. This requires Swift 6.3 (module selectors) and swift-syntax 603 (to parse the generated `::`), so the tools-version, the swift-syntax floor, and the CI matrix move to 6.3; the pre-6.3 entries are dropped.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
